### PR TITLE
Handle Framatalk.org URL

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
             <data android:host="enso.me" android:scheme="https" />
             <data android:host="hipchat.me" android:scheme="https" />
             <data android:host="meet.jit.si" android:scheme="https" />
+            <data android:host="framatalk.org" android:scheme="https" />
         </intent-filter>
         <intent-filter>
             <action android:name="android.intent.action.VIEW" />

--- a/ios/jitsi-meet-react.entitlements
+++ b/ios/jitsi-meet-react.entitlements
@@ -10,6 +10,7 @@
 		<string>applinks:enso.me</string>
 		<string>applinks:hipchat.me</string>
 		<string>applinks:meet.jit.si</string>
+		<string>applinks:framatalk.org</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Framatalk.org is a free-to-use Jitsi Meet instance operated by Framasoft, a non-profit french organisation.